### PR TITLE
Implement typing using pyright

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -643,6 +643,52 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.5.1"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
+    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
+    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
+    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
+    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
+    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
+    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
+    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
+    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
+    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
+    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
+    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
+    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
+    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
+    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
+    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
+    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
+    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
+    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1470,4 +1516,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "807a86136efd67ee5794fd83b20ec53923a05d8acf058224ea088b2aa425dbfa"
+content-hash = "4050fdd82e9fd38f7bd7c63da3a6db23f6222993ee73d7ebd7eb40f31d52f4e5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -643,52 +643,6 @@ files = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.5.1"
-description = "Optional static typing for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
-    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
-    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
-    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
-    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
-    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
-    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
-    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
-    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
-    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
-    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
-    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
-    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
-    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
-    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
-    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
-    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
-    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
-    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
-    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
-    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
-    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
-    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
-    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
-    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
-    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
-    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
-]
-
-[package.dependencies]
-mypy-extensions = ">=1.0.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = ">=4.1.0"
-
-[package.extras]
-dmypy = ["psutil (>=4.0)"]
-install-types = ["pip"]
-reports = ["lxml"]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -724,6 +678,20 @@ linkify = ["linkify-it-py (>=2.0,<3.0)"]
 rtd = ["ipython", "pydata-sphinx-theme (==v0.13.0rc4)", "sphinx-autodoc2 (>=0.4.2,<0.5.0)", "sphinx-book-theme (==1.0.0rc2)", "sphinx-copybutton", "sphinx-design2", "sphinx-pyscript", "sphinx-tippy (>=0.3.1)", "sphinx-togglebutton", "sphinxext-opengraph (>=0.8.2,<0.9.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
 testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=7,<8)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
 testing-docutils = ["pygments", "pytest (>=7,<8)", "pytest-param-files (>=0.3.4,<0.4.0)"]
+
+[[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
 
 [[package]]
 name = "packaging"
@@ -933,6 +901,24 @@ files = [
 
 [package.extras]
 plugins = ["importlib-metadata"]
+
+[[package]]
+name = "pyright"
+version = "1.1.329"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.329-py3-none-any.whl", hash = "sha256:c16f88a7ac14ddd0513e62fec56d69c37e3c6b412161ad16aa23a9c7e3dabaf4"},
+    {file = "pyright-1.1.329.tar.gz", hash = "sha256:5baf82ff5ecb8c8b3ac400e8536348efbde0b94a09d83d5b440c0d143fd151a8"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pytest"
@@ -1516,4 +1502,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4050fdd82e9fd38f7bd7c63da3a6db23f6222993ee73d7ebd7eb40f31d52f4e5"
+content-hash = "183464ba78c8677bbb8405558370fbef20813689bb918b87089e17e379c7747d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ trilium-client = "^0.1.0"
 black = "^23.3.0"
 furo = "^2023.5.20"
 genbadge = {extras = ["all"], version = "^1.1.0"}
-mypy = "^1.5.1"
 myst-parser = "^2.0.0"
 pytest = "^7.3.1"
 pytest-cov = "^4.1.0"
@@ -40,6 +39,7 @@ sphinx-autodoc2 = {git = "https://github.com/mm21/sphinx-autodoc2.git"}
 sphinx-copybutton = "^0.5.2"
 sphinxcontrib-plantuml = "^0.25"
 toml-sort = "^0.23.1"
+pyright = "^1.1.329"
 
 [tool.black]
 include = '\.pyi?$|SConstruct$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,51 +8,51 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Development Status :: 3 - Alpha",
   "Natural Language :: English",
-  "License :: OSI Approved :: GNU Affero General Public License v3",
+  "License :: OSI Approved :: GNU Affero General Public License v3"
 ]
 description = "Python SDK and CLI toolkit for Trilium Notes"
 documentation = "https://mm21.github.io/trilium-alchemy/"
 homepage = "https://github.com/mm21/trilium-alchemy"
 name = "trilium-alchemy"
-packages = [{ include = "trilium_alchemy" }]
+packages = [{include = "trilium_alchemy"}]
 readme = "README.pypi.md"
 version = "0.1.7"
 
 [tool.poetry.dependencies]
-pydantic       = "^1.10.12"
-python         = "^3.10"
-requests       = "^2.31.0"
+pydantic = "^1.10.12"
+python = "^3.10"
+requests = "^2.31.0"
 trilium-client = "^0.1.0"
 
 [tool.poetry.group.dev.dependencies]
-black                  = "^23.3.0"
-furo                   = "^2023.5.20"
-genbadge               = { extras = ["all"], version = "^1.1.0" }
-myst-parser            = "^2.0.0"
-pytest                 = "^7.3.1"
-pytest-cov             = "^4.1.0"
-pytest-dependency      = "^0.5.1"
-python-dotenv          = "^1.0.0"
-scons                  = "^4.5.2"
-sphinx                 = "^7.0.1"
-sphinx-autodoc2        = { git = "https://github.com/mm21/sphinx-autodoc2.git" }
-sphinx-copybutton      = "^0.5.2"
-sphinxcontrib-plantuml = "^0.25"
-toml-sort              = "^0.23.1"
+black = "^23.3.0"
+furo = "^2023.5.20"
+genbadge = {extras = ["all"], version = "^1.1.0"}
 mypy = "^1.5.1"
+myst-parser = "^2.0.0"
+pytest = "^7.3.1"
+pytest-cov = "^4.1.0"
+pytest-dependency = "^0.5.1"
+python-dotenv = "^1.0.0"
+scons = "^4.5.2"
+sphinx = "^7.0.1"
+sphinx-autodoc2 = {git = "https://github.com/mm21/sphinx-autodoc2.git"}
+sphinx-copybutton = "^0.5.2"
+sphinxcontrib-plantuml = "^0.25"
+toml-sort = "^0.23.1"
 
 [tool.black]
-include     = '\.pyi?$|SConstruct$'
+include = '\.pyi?$|SConstruct$'
 line-length = 80
 
 [tool.tomlsort]
-no_sort_tables  = true
+no_sort_tables = true
 sort_table_keys = true
 
 [tool.mypy]
 ignore_missing_imports = true
-python_version         = "3.10"
+python_version = "3.10"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires      = ["poetry-core"]
+requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ sphinx-autodoc2        = { git = "https://github.com/mm21/sphinx-autodoc2.git" }
 sphinx-copybutton      = "^0.5.2"
 sphinxcontrib-plantuml = "^0.25"
 toml-sort              = "^0.23.1"
+mypy = "^1.5.1"
 
 [tool.black]
 include     = '\.pyi?$|SConstruct$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,46 +8,50 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Development Status :: 3 - Alpha",
   "Natural Language :: English",
-  "License :: OSI Approved :: GNU Affero General Public License v3"
+  "License :: OSI Approved :: GNU Affero General Public License v3",
 ]
 description = "Python SDK and CLI toolkit for Trilium Notes"
 documentation = "https://mm21.github.io/trilium-alchemy/"
 homepage = "https://github.com/mm21/trilium-alchemy"
 name = "trilium-alchemy"
-packages = [{include = "trilium_alchemy"}]
+packages = [{ include = "trilium_alchemy" }]
 readme = "README.pypi.md"
 version = "0.1.7"
 
 [tool.poetry.dependencies]
-pydantic = "^1.10.12"
-python = "^3.10"
-requests = "^2.31.0"
+pydantic       = "^1.10.12"
+python         = "^3.10"
+requests       = "^2.31.0"
 trilium-client = "^0.1.0"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.3.0"
-furo = "^2023.5.20"
-genbadge = {extras = ["all"], version = "^1.1.0"}
-myst-parser = "^2.0.0"
-pytest = "^7.3.1"
-pytest-cov = "^4.1.0"
-pytest-dependency = "^0.5.1"
-python-dotenv = "^1.0.0"
-scons = "^4.5.2"
-sphinx = "^7.0.1"
-sphinx-autodoc2 = {git = "https://github.com/mm21/sphinx-autodoc2.git"}
-sphinx-copybutton = "^0.5.2"
+black                  = "^23.3.0"
+furo                   = "^2023.5.20"
+genbadge               = { extras = ["all"], version = "^1.1.0" }
+myst-parser            = "^2.0.0"
+pytest                 = "^7.3.1"
+pytest-cov             = "^4.1.0"
+pytest-dependency      = "^0.5.1"
+python-dotenv          = "^1.0.0"
+scons                  = "^4.5.2"
+sphinx                 = "^7.0.1"
+sphinx-autodoc2        = { git = "https://github.com/mm21/sphinx-autodoc2.git" }
+sphinx-copybutton      = "^0.5.2"
 sphinxcontrib-plantuml = "^0.25"
-toml-sort = "^0.23.1"
+toml-sort              = "^0.23.1"
 
 [tool.black]
-include = '\.pyi?$|SConstruct$'
+include     = '\.pyi?$|SConstruct$'
 line-length = 80
 
 [tool.tomlsort]
-no_sort_tables = true
+no_sort_tables  = true
 sort_table_keys = true
+
+[tool.mypy]
+ignore_missing_imports = true
+python_version         = "3.10"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires      = ["poetry-core"]

--- a/trilium_alchemy/core/attribute/relation.py
+++ b/trilium_alchemy/core/attribute/relation.py
@@ -43,7 +43,7 @@ class Relation(Attribute):
         name: str,
         target: note.Note,
         inheritable: bool = False,
-        session: Session = None,
+        session: Session | None = None,
         **kwargs,
     ):
         """

--- a/trilium_alchemy/core/declarative.py
+++ b/trilium_alchemy/core/declarative.py
@@ -144,7 +144,7 @@ def relation(
     @check_name(name, accumulate=accumulate)
     def init(self, attributes: list[Attribute], children: list[Branch]):
         assert (
-            target_cls._is_singleton
+            target_cls._is_singleton()
         ), f"Relation target {target_cls} must have a deterministic id by setting a note_id, note_id_seed, or singleton = True"
 
         # instantiate target first

--- a/trilium_alchemy/core/entity/entity.py
+++ b/trilium_alchemy/core/entity/entity.py
@@ -471,14 +471,14 @@ class EntityIdDescriptor:
 
     @overload
     def __get__(
-        self, ent: EntityIdDescriptor, objtype=type[EntityIdDescriptor]
+        self, ent: EntityIdDescriptor, objtype=type["EntityIdDescriptor"]
     ) -> str:
         ...
 
     def __get__(
         self,
         ent: EntityIdDescriptor | None,
-        objtype: type[EntityIdDescriptor] | None = None,
+        objtype: type["EntityIdDescriptor"] | None = None,
     ) -> EntityIdDescriptor | str:
         if ent is None:
             return self

--- a/trilium_alchemy/core/entity/entity.py
+++ b/trilium_alchemy/core/entity/entity.py
@@ -470,21 +470,19 @@ class EntityIdDescriptor:
         ...
 
     @overload
-    def __get__(
-        self, ent: EntityIdDescriptor, objtype=type["EntityIdDescriptor"]
-    ) -> str:
+    def __get__(self, ent: Entity, objtype: type[Entity]) -> str:
         ...
 
     def __get__(
         self,
-        ent: EntityIdDescriptor | None,
-        objtype: type["EntityIdDescriptor"] | None = None,
+        ent: Entity | None,
+        objtype: type[Entity] | None = None,
     ) -> EntityIdDescriptor | str:
         if ent is None:
             return self
         return cast(str, ent._entity_id)
 
-    def __set__(self, ent, val):
+    def __set__(self, ent: Entity, val: Any):
         raise ReadOnlyError("_entity_id", ent)
 
 

--- a/trilium_alchemy/core/entity/entity.py
+++ b/trilium_alchemy/core/entity/entity.py
@@ -492,7 +492,7 @@ class SupportConstructor(Iterable, Protocol):
 
 
 def normalize_entities(
-    entities: Entity | Iterable[Entity],
+    entities: Entity | tuple | Iterable[Entity | tuple],
     collection_cls: Type[SupportConstructor] = list,
 ) -> Iterable[Entity]:
     """

--- a/trilium_alchemy/core/entity/model.py
+++ b/trilium_alchemy/core/entity/model.py
@@ -166,7 +166,11 @@ class Model(ABC):
 
     @classmethod
     @property
-    def fields_update_alias(cls):
+    def fields_update_alias(cls) -> Iterable[str]:
+        """
+        Maps aliased fields to canonical fields using fields_alias if
+        provided.
+        """
         if cls.fields_alias:
             fields_update = cls.fields_update.copy()
             for alias, field in cls.fields_alias.items():

--- a/trilium_alchemy/core/note/note.py
+++ b/trilium_alchemy/core/note/note.py
@@ -29,7 +29,7 @@ from ..entity.model import (
 # isort: on
 
 from ..exceptions import *
-from ..session import Session, require_session
+from ..session import Session, SessionContainer, require_session
 from .attributes import Attributes, ValueSpec
 from .branches import Branches, Children, Parents
 from .content import Content, ContentDescriptor
@@ -118,7 +118,10 @@ def patch_init(init, doc: str | None = None):
 
         @wraps(init_decl_old)
         def _init_decl(
-            self, cls_decl, attributes: list[Attribute], children: list[ChildSpecT]
+            self,
+            cls_decl,
+            attributes: list[Attribute],
+            children: list[ChildSpecT],
         ):
             if cls is cls_decl:
                 # invoke init patch
@@ -238,7 +241,7 @@ class Meta(ABCMeta):
         return note_cls
 
 
-class Mixin(ABC, metaclass=Meta):
+class Mixin(ABC, SessionContainer, metaclass=Meta):
     """
     Reusable collection of attributes, children, and fields
     (`note_id`, `title`, `type`, `mime`) which can be inherited by a
@@ -350,9 +353,9 @@ class Mixin(ABC, metaclass=Meta):
     child ids.
     """
 
-    _child_id_seed: str|None = None
+    _child_id_seed: str | None = None
 
-    def __init__(self, child_id_seed: str|None):
+    def __init__(self, child_id_seed: str | None):
         self._sequence_map = dict()
         self._child_id_seed = child_id_seed
 

--- a/trilium_alchemy/core/session.py
+++ b/trilium_alchemy/core/session.py
@@ -630,12 +630,22 @@ class Session:
         return default_session is self
 
 
-"""
-Decorator to use default Session if none provided.
-"""
+class SessionContainer:
+    """
+    Indicates that an object is associated with a Session.
+    """
+
+    _session: Session
+
+    def __init__(self, session: Session):
+        self._session = session
 
 
 def require_session(func):
+    """
+    Decorator to use default Session if none provided.
+    """
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         # validate session


### PR DESCRIPTION
This includes work on making EntityIdDescriptor usage pass typing checks.

The changes here remove a number of warnings and errors, the issue I have not resolved fields like note_id that are "str | None" in the Mixin and "EntityIdDescriptor | str | None" in the class Note.

I use the command:

`mypy trilium_alchemy/core/note/note.py |grep note.py |less`

`trilium_alchemy/core/note/note.py:605: error: Incompatible types in assignment (expression has type "EntityIdDescriptor | str | None", base class "Mixin" defined the type as "str | None")  [assignment]`

to review mypy errors and warnings.

The pyproject.toml changes are just for research, they will be rolled into a poetry setup if this work progresses.