### PR TITLE
Update declarative Note types

### DIFF
--- a/trilium_alchemy/ext/types.py
+++ b/trilium_alchemy/ext/types.py
@@ -6,9 +6,11 @@ from ..core import Note
 
 __all__ = [
     "CodeNote",
-    "JsFrontendNote",
-    "JsBackendNote",
     "CssNote",
+    "HtmlNote",
+    "JsBackendNote",
+    "JsFrontendNote",
+    "TextNote",
 ]
 
 
@@ -26,6 +28,7 @@ class JsFrontendNote(CodeNote):
     """
 
     mime = "application/javascript;env=frontend"
+    icon = "bx bxl-javascript"
 
 
 class JsBackendNote(CodeNote):
@@ -34,6 +37,7 @@ class JsBackendNote(CodeNote):
     """
 
     mime = "application/javascript;env=backend"
+    icon = "bx bxl-javascript"
 
 
 class CssNote(CodeNote):
@@ -42,3 +46,22 @@ class CssNote(CodeNote):
     """
 
     mime = "text/css"
+    icon = "bx bxs-file-css"
+
+
+class HtmlNote(CodeNote):
+    """
+    Defines a HTML note.
+    """
+
+    mime = "text/html"
+    icon = "bx bxs-file-html"
+
+
+class TextNote(CodeNote):
+    """
+    Defines a text note.
+    """
+
+    mime = "text/plain"
+    icon = "bx bx-text"


### PR DESCRIPTION
* Add HtmlNote and TextNote types
* Add default icons to Note types

* Other Note types could be added but this appears to complete the "set" that could be included in a plugin/extension
* I added default icons  because I like the visual clues